### PR TITLE
MODRR-32: Fix querying by enum values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <folio-spring-support.version>9.0.0</folio-spring-support.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <mvn-failsafe.version>3.5.2</mvn-failsafe.version>
+    <hibernate.version>6.5.3.Final</hibernate.version>
 
     <!-- test dependencies -->
     <wiremock.version>3.12.0</wiremock.version>

--- a/src/main/java/org/folio/readingroom/domain/entity/AccessLogEntity.java
+++ b/src/main/java/org/folio/readingroom/domain/entity/AccessLogEntity.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.folio.readingroom.domain.base.AuditableEntity;
 import org.folio.readingroom.domain.dto.AccessLog.ActionEnum;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Getter
@@ -29,7 +31,8 @@ public class AccessLogEntity extends AuditableEntity {
   private UUID patronId;
 
   @Enumerated(EnumType.STRING)
-  @Column(name = "action", nullable = false)
+  @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+  @Column(name = "action", columnDefinition = "accessLogActionEnum", nullable = false)
   private ActionEnum action;
 
   @Column(name = "reading_room_id", nullable = false)


### PR DESCRIPTION
## Purpose
_Allows to query reading rooms access logs using enumerated values._

## Approach
- Downgrade version of hibernate to v6.5.3.Final, cause newer version require refactoring code of [org.folio.spring.cql.Cql2JpaCriteria#queryBySql](https://github.com/folio-org/folio-spring-support/blob/master/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java#L469), which can affect other projects in future
```java
    // ...
    } else if (javaType.isEnum()) {
      term = term != null ? Enum.valueOf(javaType, toRootUpperCase(value)) : null;
    }
    // ...
```
